### PR TITLE
Allow control over SQL column names of queries

### DIFF
--- a/src/Opaleye/Internal/Aggregate.hs
+++ b/src/Opaleye/Internal/Aggregate.hs
@@ -122,8 +122,8 @@ extractAggregateFields
 extractAggregateFields tag (m, pe) = do
   i <- PM.new
 
-  let souter = HPQ.Symbol ("result" ++ i) tag
-      sinner = HPQ.Symbol ("inner" ++ i) tag
+  let souter = HPQ.Symbol ("result" ++ i) (Just tag)
+      sinner = HPQ.Symbol ("inner" ++ i) (Just tag)
 
   PM.write ((souter, (m, sinner)), (sinner, pe))
 

--- a/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
+++ b/src/Opaleye/Internal/HaskellDB/PrimQuery.hs
@@ -15,7 +15,7 @@ type Name = String
 type Scheme     = [Attribute]
 type Assoc      = [(Attribute,PrimExpr)]
 
-data Symbol = Symbol String T.Tag deriving (Read, Show)
+data Symbol = Symbol String (Maybe T.Tag) deriving (Read, Show)
 
 data PrimExpr   = AttrExpr  Symbol
                 | BaseTableAttrExpr Attribute

--- a/src/Opaleye/Internal/PackMap.hs
+++ b/src/Opaleye/Internal/PackMap.hs
@@ -98,7 +98,7 @@ extractAttrPE :: (primExpr -> String -> String)
               -> PM [(HPQ.Symbol, primExpr)] HPQ.PrimExpr
 extractAttrPE mkName t pe = do
   i <- new
-  let s = HPQ.Symbol (mkName pe i) t
+  let s = HPQ.Symbol (mkName pe i) (Just t)
   write (s, pe)
   return (HPQ.AttrExpr s)
 

--- a/src/Opaleye/Internal/Print.hs
+++ b/src/Opaleye/Internal/Print.hs
@@ -202,8 +202,8 @@ ppDeleteReturning (Sql.Returning delete returnExprs) =
 -- * Bits from "Opaleye.Sql".  They don't really belong here but I
 -- * have to put them somewhere.
 
-formatAndShowSQL :: ([HPQ.PrimExpr], PQ.PrimQuery' a, T.Tag) -> Maybe String
-formatAndShowSQL = fmap (show . ppSql . Sql.sql) . traverse2Of3 Op.removeEmpty
+formatAndShowSQL :: Bool -> ([HPQ.PrimExpr], PQ.PrimQuery' a, T.Tag) -> Maybe String
+formatAndShowSQL rename = fmap (show . ppSql . Sql.sql rename) . traverse2Of3 Op.removeEmpty
   where -- Just a lens
         traverse2Of3 :: Functor f => (a -> f b) -> (x, a, y) -> f (x, b, y)
         traverse2Of3 f (x, y, z) = fmap (\y' -> (x, y', z)) (f y)

--- a/src/Opaleye/Internal/Sql.hs
+++ b/src/Opaleye/Internal/Sql.hs
@@ -120,7 +120,7 @@ sql (pes, pq, t) = SelectFrom $ newSelect { attrs = SelectAttrs (ensureColumns (
                                           , tables = oneTable pqSelect }
   where pqSelect = PQ.foldPrimQuery sqlQueryGenerator pq
         makeAttrs = flip (zipWith makeAttr) [1..]
-        makeAttr pe i = sqlBinding (Symbol ("result" ++ show (i :: Int)) t, pe)
+        makeAttr pe i = sqlBinding (Symbol ("result" ++ show (i :: Int)) (Just t), pe)
 
 unit :: Select
 unit = SelectFrom newSelect { attrs  = SelectAttrs (ensureColumns []) }

--- a/src/Opaleye/Internal/Tag.hs
+++ b/src/Opaleye/Internal/Tag.hs
@@ -12,5 +12,6 @@ next = UnsafeTag . (+1) . unsafeUnTag
 unsafeUnTag :: Tag -> Int
 unsafeUnTag (UnsafeTag i) = i
 
-tagWith :: Tag -> String -> String
-tagWith t s = s ++ "_" ++ show (unsafeUnTag t)
+tagWith :: Maybe Tag -> String -> String
+tagWith Nothing s = s
+tagWith (Just t) s = s ++ "_" ++ show (unsafeUnTag t)

--- a/src/Opaleye/Sql.hs
+++ b/src/Opaleye/Sql.hs
@@ -6,6 +6,7 @@ module Opaleye.Sql (
   showSqlUnopt,
   -- * Explicit versions
   showSqlExplicit,
+  showSqlExplicitNoRename,
   showSqlUnoptExplicit,
   -- * Deprecated functions
   showSqlForPostgres,
@@ -55,12 +56,17 @@ showSqlUnopt :: forall fields.
 showSqlUnopt = showSqlUnoptExplicit (D.def :: U.Unpackspec fields fields)
 
 showSqlExplicit :: U.Unpackspec fields b -> S.Select fields -> Maybe String
-showSqlExplicit = Pr.formatAndShowSQL
+showSqlExplicit = Pr.formatAndShowSQL True
                   . (\(x, y, z) -> (x, Op.optimize y, z))
                   .: Q.runQueryArrUnpack
 
+showSqlExplicitNoRename :: U.Unpackspec fields b -> S.Select fields -> Maybe String
+showSqlExplicitNoRename = Pr.formatAndShowSQL False
+                          . (\(x, y, z) -> (x, Op.optimize y, z))
+                          .: Q.runQueryArrUnpack
+
 showSqlUnoptExplicit :: U.Unpackspec fields b -> S.Select fields -> Maybe String
-showSqlUnoptExplicit = Pr.formatAndShowSQL .: Q.runQueryArrUnpack
+showSqlUnoptExplicit = Pr.formatAndShowSQL True .: Q.runQueryArrUnpack
 
 {-# DEPRECATED showSqlForPostgres "Will be removed in version 0.8.  Use 'showSql' instead." #-}
 showSqlForPostgres :: forall columns . D.Default U.Unpackspec columns columns =>


### PR DESCRIPTION
This PR makes two changes to Opaleye: one to allow `Symbol`s without `Tag`s (i.e., column names like `"foo"` instead of `"foo_1"` (the default is still `"foo_1"`)), and the other to optionally turn off the final renaming step in `Opaleye.showSqlExplicit`, so that the column names of the underlying query are preserved (not overwritten with `result0_1` etc).